### PR TITLE
Fix register and change customer data models

### DIFF
--- a/source/ecruise.Api/Controllers/CustomersController.cs
+++ b/source/ecruise.Api/Controllers/CustomersController.cs
@@ -205,7 +205,7 @@ namespace ecruise.Api.Controllers
                 customer.ZipCode = address.ZipCode;
                 customer.Street = address.Street;
                 customer.HouseNumber = address.HouseNumber;
-                customer.AddressExtraLine = address.AdressExtraLine;
+                customer.AddressExtraLine = address.AddressExtraLine;
 
                 transaction.Commit();
 

--- a/source/ecruise.Database/Models/Customer.cs
+++ b/source/ecruise.Database/Models/Customer.cs
@@ -23,7 +23,7 @@ namespace ecruise.Database.Models
         public string LastName { get; set; }
         public string Country { get; set; }
         public string City { get; set; }
-        public uint ZipCode { get; set; }
+        public uint? ZipCode { get; set; }
         public string Street { get; set; }
         public string HouseNumber { get; set; }
         public string AddressExtraLine { get; set; }

--- a/source/ecruise.Models/Customer.cs
+++ b/source/ecruise.Models/Customer.cs
@@ -30,7 +30,7 @@ namespace ecruise.Models
         /// <param name="activated">True if the user has activated his account by clicking on the link in the activation email.</param>
         /// <param name="verified">True if the user has verified his account at our head-quarter by bringing us his driver's license.</param>
         public Customer(uint customerId, string email, string phoneNumber, string chipCardUid, string firstName,
-            string lastName, string country, string city, uint zipCode, string street, string houseNumber,
+            string lastName, string country, string city, uint? zipCode, string street, string houseNumber,
             string addressExtraLine, bool activated = false, bool verified = false)
         {
             CustomerId = customerId;
@@ -71,7 +71,7 @@ namespace ecruise.Models
         /// <summary>
         /// Gets or Sets PhoneNumber
         /// </summary>
-        [Required, StringLength(32)]
+        [StringLength(32)]
         public string PhoneNumber { get; set; }
 
         /// <summary>
@@ -89,31 +89,31 @@ namespace ecruise.Models
         /// <summary>
         /// Gets or Sets Country
         /// </summary>
-        [Required, StringLength(2, MinimumLength = 2)]
+        [StringLength(2, MinimumLength = 2)]
         public string Country { get; set; }
 
         /// <summary>
         /// Gets or Sets City
         /// </summary>
-        [Required, StringLength(64)]
+        [StringLength(64)]
         public string City { get; set; }
 
         /// <summary>
         /// Gets or Sets ZipCode
         /// </summary>
-        [Required, Range(1001, 99999)]
-        public uint ZipCode { get; set; }
+        [Range(1001, 99999)]
+        public uint? ZipCode { get; set; }
 
         /// <summary>
         /// Gets or Sets Street
         /// </summary>
-        [Required, StringLength(128)]
+        [StringLength(128)]
         public string Street { get; set; }
 
         /// <summary>
         /// Gets or Sets HouseNumber
         /// </summary>
-        [Required, StringLength(8)]
+        [StringLength(8)]
         public string HouseNumber { get; set; }
 
         /// <summary>
@@ -297,16 +297,16 @@ namespace ecruise.Models
         /// <param name="zipCode">ZipCode (required)</param>
         /// <param name="street">Street (required)</param>
         /// <param name="houseNumber">HouseNumber (required)</param>
-        /// <param name="adressExtraLine">AdressExtraLine</param>
+        /// <param name="addressExtraLine">AdressExtraLine</param>
         public Address(string country, string city, uint zipCode, string street, string houseNumber,
-            string adressExtraLine)
+            string addressExtraLine)
         {
             Country = country;
             City = city;
             ZipCode = zipCode;
             Street = street;
             HouseNumber = houseNumber;
-            AdressExtraLine = adressExtraLine;
+            AddressExtraLine = addressExtraLine;
         }
 
         [Required, StringLength(2, MinimumLength = 2)]
@@ -324,7 +324,7 @@ namespace ecruise.Models
         [Required, StringLength(8)]
         public string HouseNumber { get; }
 
-        public string AdressExtraLine { get; }
+        public string AddressExtraLine { get; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -339,7 +339,7 @@ namespace ecruise.Models
             sb.Append("  ZipCode: ").Append(ZipCode).Append("\n");
             sb.Append("  Street: ").Append(Street).Append("\n");
             sb.Append("  HouseNumber: ").Append(HouseNumber).Append("\n");
-            sb.Append("  AdressExtraLine: ").Append(AdressExtraLine).Append("\n");
+            sb.Append("  AdressExtraLine: ").Append(AddressExtraLine).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -382,7 +382,7 @@ namespace ecruise.Models
                 (ZipCode == other.ZipCode || ZipCode.Equals(other.ZipCode)) &&
                 (Street == other.Street || Street.Equals(other.Street)) &&
                 (HouseNumber == other.HouseNumber || HouseNumber.Equals(other.HouseNumber)) &&
-                (AdressExtraLine == other.AdressExtraLine || AdressExtraLine.Equals(other.AdressExtraLine));
+                (AddressExtraLine == other.AddressExtraLine || AddressExtraLine.Equals(other.AddressExtraLine));
         }
 
         /// <summary>
@@ -400,7 +400,7 @@ namespace ecruise.Models
                 hash = hash * 59 + ZipCode.GetHashCode();
                 hash = hash * 59 + Street.GetHashCode();
                 hash = hash * 59 + HouseNumber.GetHashCode();
-                hash = hash * 59 + AdressExtraLine.GetHashCode();
+                hash = hash * 59 + AddressExtraLine.GetHashCode();
 
                 return hash;
             }


### PR DESCRIPTION
By setting non needed fields as nullable in the database it is now possible to create new customers with only email, first name, last name and password. For this following fields must be set nullable in the database:
• PhoneNumber
• Country
• City
• ZipCode
• Street
• HouseNumber
• AddressExtraLine